### PR TITLE
Add package.json exports property

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "typings": "dist/index.d.ts",
+  "type": "module",
+  "exports": {
+    "import": "./dist/index.esm.js",
+    "require": "./dist/index.cjs.js"
+  },
   "scripts": {
     "test": "ts-node node_modules/tape/bin/tape test/**/*.ts",
     "prepublishOnly": "npm test && npm run lint && npm run build",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "typings": "dist/index.d.ts",
-  "type": "module",
   "exports": {
     "import": "./dist/index.esm.js",
     "require": "./dist/index.cjs.js"


### PR DESCRIPTION
This allows modern build systems (vite) to properly use the correct module type (ESM). See [https://github.com/chartjs/Chart.js/pull/9597](https://github.com/chartjs/Chart.js/pull/9597) for more details. It would be great to add the same exports property also to the other mathigon packages.