### PR TITLE
Add `line.flip` method

### DIFF
--- a/src/line.ts
+++ b/src/line.ts
@@ -144,6 +144,11 @@ export class Line implements GeoShape {
     return this.shift(p.x, p.y);
   }
 
+  /** Reverse the line's start and end points. */
+  flip() {
+    return this.make(this.p2, this.p1)
+  }
+
   equals(other: Line, tolerance?: number) {
     // Note: Checking line types breaks some applications in Mathigon textbooks.
     // if (other.type !== 'line') return false;

--- a/test/line-test.ts
+++ b/test/line-test.ts
@@ -42,3 +42,12 @@ tape('line intercepts', (test) => {
 
   test.end();
 });
+
+tape('flip', (test) => {
+  const a = new Line(new Point(1, 1), new Point(2, 2));
+  const b = a.flip();
+  test.equals(b.p1, a.p2);
+  test.equals(b.p2, a.p1);
+
+  test.end();
+});


### PR DESCRIPTION
This adds a `line.flip` method which reverses the two points of lines, segments, or rays. 

Lots of uses, but for example useful when you want to interpolate between two line segments but want to ensure they are both oriented the same way first.