### PR TITLE
Add `segment.part` method

### DIFF
--- a/src/line.ts
+++ b/src/line.ts
@@ -209,7 +209,12 @@ export class Segment extends Line {
 
   /** Contracts (or expands) a line by a specific ratio. */
   contract(x: number) {
-    return new Segment(this.at(x), this.at(1 - x));
+    return this.part(x, 1 - x);
+  }
+
+  /** Get part of a segment from a start to end ratio. */
+  part(a: number, b: number) {
+    return new Segment(this.at(a), this.at(b));
   }
 
   equals(other: Segment, tolerance?: number, oriented = false) {

--- a/test/line-test.ts
+++ b/test/line-test.ts
@@ -6,7 +6,7 @@
 
 import {nearlyEquals} from '@mathigon/fermat';
 import tape from 'tape';
-import {Line, Point} from '../src';
+import {Line, Point, Segment} from '../src';
 
 
 tape('offset and projections', (test) => {
@@ -42,3 +42,13 @@ tape('line intercepts', (test) => {
 
   test.end();
 });
+
+tape('segment part', (test) => {
+  const a = new Segment(new Point(1, 1), new Point(2, 2));
+  const b = a.part(0.25, 0.75);
+  test.true(b.p1.equals(new Point(1.25, 1.25)));
+  test.true(b.p2.equals(new Point(1.75, 1.75)));
+
+  test.end();
+});
+


### PR DESCRIPTION
This adds a `segment.part` method for easily creating a new line segment that is a subset of an existing one. So for example to get the 2nd quarter you could do:

```ts
segment.part(0.25, 0.5)
```

Could also be called `slice` (or `subset` or `section`), let me know.