### PR TITLE
Scale center when scaling ellipse

### DIFF
--- a/src/ellipse.ts
+++ b/src/ellipse.ts
@@ -126,7 +126,7 @@ export class Ellipse implements GeoShape {
   }
 
   scale(sx: number, sy = sx) {
-    return new Ellipse(this.c, this.a * sx, this.b * sy, this.angle);
+    return new Ellipse(this.c.scale(sx, sy), this.a * sx, this.b * sy, this.angle);
   }
 
   shift(x: number, y = x) {

--- a/test/ellipse-test.ts
+++ b/test/ellipse-test.ts
@@ -28,10 +28,11 @@ tape('vertical', (test) => {
 });
 
 tape('scale', (test) => {
-  const ellipse = new Ellipse(ORIGIN, 2, 1);
+  const ellipse = new Ellipse(new Point(1, 1), 2, 1);
   const scaled = ellipse.scale(2);
-  test.true(scaled.f1.equals(new Point(-Math.sqrt(3) * 2, 0)));
-  test.true(scaled.f2.equals(new Point(Math.sqrt(3) * 2, 0)));
+  test.true(scaled.f1.equals(new Point(2 - Math.sqrt(12), 2)));
+  test.true(scaled.f2.equals(new Point(2 + Math.sqrt(12), 2)));
+  test.true(scaled.c.equals(new Point(2, 2)));
   test.end();
 });
 


### PR DESCRIPTION
The scale method on the ellipse scales the center point as well. So the behavior is the same as in the circle.